### PR TITLE
API contract version for API replace value should be #.x

### DIFF
--- a/dev-guide/conf.py
+++ b/dev-guide/conf.py
@@ -131,7 +131,7 @@ extlinks = {
 rst_epilog = """
 .. |apiservice| replace:: Rackspace Cloud Servers API
 .. |no changes| replace:: None for this release.
-.. |contract version| replace:: v2
+.. |contract version| replace:: 2.0
 """
 
 


### PR DESCRIPTION
When we did the original dev guide migration, Kelly advised us to specify the contract as "1.0" or "2.0" with no "v" or version.

The "v" designation is useful for services that have service updates with a corresponding release number, for example Load Balancers is contract version 1.0, service update version "v2.#.."