### PR TITLE
Updated release note navigation title to remove repetition of "API 2.0"

### DIFF
--- a/dev-guide/release-notes.rst
+++ b/dev-guide/release-notes.rst
@@ -12,11 +12,11 @@ resolved issues, and other important details about |apiservice| |version| servic
 .. toctree::
    :maxdepth: 2
 
-   release-notes/cs_v2_20150602
-   release-notes/cs_v2_20141030
-   release-notes/cs_v2_20140724
-   release-notes/cs_v2_20120821
-   release-notes/cs_v2_20120815
-   release-notes/cs_v2_20120709
-   release-notes/cs_v2_20120613
-   release-notes/cs_v2_20120501
+   June 2, 2015 <release-notes/cs_v2_20150602>
+   October 30, 2014 <release-notes/cs_v2_20141030>
+   July 24, 2014 <release-notes/cs_v2_20140724>
+   August 21, 2012 <release-notes/cs_v2_20120821>
+   August 15, 2012 <release-notes/cs_v2_20120815>
+   July 9, 2012 <release-notes/cs_v2_20120709>
+   June 13, 2012 <release-notes/cs_v2_20120613>
+   May 1, 2012 <release-notes/cs_v2_20120501>


### PR DESCRIPTION
Does not change the topic title.