### PR TITLE
Update standard flavors characteristics list

### DIFF
--- a/api-docs/general-api-info/flavors.rst
+++ b/api-docs/general-api-info/flavors.rst
@@ -197,7 +197,6 @@ This table shows some of the common supported flavors for Cloud Servers:
 
 **Table: Supported Flavors for Cloud Servers**
 
-
 +-------------------------+-----------------------------------+-------------+-------+-----------+-------+-------------+
 | ID                      | Flavor name                       | Memory (MB) | Disk  | Ephemeral | VCPUs | RXTX factor |
 +=========================+===================================+=============+=======+===========+=======+=============+

--- a/api-docs/general-api-info/flavors.rst
+++ b/api-docs/general-api-info/flavors.rst
@@ -17,8 +17,7 @@ Virtual Cloud Server Flavors are divided into the following classes:
 
 **Standard**
 
-    These flavors, which are being phased out and should not be used for
-    new servers, have the following characteristics:
+    Rackspace legacy flavors have the following characteristics:
 
     -  Sizes range from 512 MB to 30 GB.
 


### PR DESCRIPTION
Hello Infodev team,
 
I would like to request an update to the content at the following link:
  https://developer.rackspace.com/docs/cloud-servers/v2/general-api-info/flavors/
  
 WAS:
“Standard
 
These flavors, which are being phased out and should not be used for new servers, have the following characteristics:”
 
IS:
“Standard
 
Our legacy flavors have the following characteristics”
 
Thank you!
 
-Mike