### PR TITLE
fix null parameter in docs for some methods

### DIFF
--- a/api-docs/api-reference/methods/post-lock-specified-server-servers-server-id-actions.rst
+++ b/api-docs/api-reference/methods/post-lock-specified-server-servers-server-id-actions.rst
@@ -76,7 +76,7 @@ This table shows the body parameters for the request:
 .. code::
 
    {
-       "lock" : "null"
+       "lock" : null
    }
 
 

--- a/api-docs/api-reference/methods/post-reset-network-for-specified-server-servers-server-id-actions.rst
+++ b/api-docs/api-reference/methods/post-reset-network-for-specified-server-servers-server-id-actions.rst
@@ -80,7 +80,7 @@ This table shows the body parameters for the request:
 .. code::
 
    {
-       "resetNetwork" : "null"
+       "resetNetwork" : null
    }
 
 

--- a/api-docs/api-reference/methods/post-start-specified-server-servers-server-id-actions.rst
+++ b/api-docs/api-reference/methods/post-start-specified-server-servers-server-id-actions.rst
@@ -83,7 +83,7 @@ This table shows the body parameters for the request:
 .. code::
 
    {
-       "os-start" : "null"
+       "os-start" : null
    }
 
 

--- a/api-docs/api-reference/methods/post-stop-specified-server-servers-server-id-actions.rst
+++ b/api-docs/api-reference/methods/post-stop-specified-server-servers-server-id-actions.rst
@@ -89,7 +89,7 @@ This table shows the body parameters for the request:
 .. code::
 
    {
-       "os-stop" : "null"
+       "os-stop" : null
    }
 
 

--- a/api-docs/api-reference/methods/post-unlock-specified-server-servers-server-id-actions.rst
+++ b/api-docs/api-reference/methods/post-unlock-specified-server-servers-server-id-actions.rst
@@ -80,7 +80,7 @@ This table shows the body parameters for the request:
 .. code::
 
    {
-       "unlock" : "null"
+       "unlock" : null
    }
 
 


### PR DESCRIPTION
The documentation (and the code) expect these fields to be either an
object or nothing, symbolized by the value null. The documentation
demonstrated this with the string value "null" instead of the actual
value which is incorrect.
